### PR TITLE
Upgrading Neat to 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,9 +19,9 @@
   ],
   "devDependencies": {
     "bourbon": "~4.2.2",
-    "neat": "~1.7.2",
     "normalize.css": "~3.0.3",
-    "meyer-reset": "*"
+    "meyer-reset": "*",
+    "neat": "^2.0.0"
   },
   "description": "Components for the Forward Framework."
 }


### PR DESCRIPTION
Work in progress.

Lots of changes need to be made in order to upgrade from Neat 1.7.2 to 2.0.0.

- [ ] Review Neat changelog for removed, changed, and deprecated variables/mixins/etc (https://github.com/thoughtbot/neat/blob/master/CHANGELOG.md).
- [ ] Update Forward to utilize these new mixins and variables.
- [ ] Refactor any code no longer necessary for Neat 2.0.0